### PR TITLE
Bug fixes

### DIFF
--- a/src/Overlay/Window/MainWindow.cpp
+++ b/src/Overlay/Window/MainWindow.cpp
@@ -155,7 +155,8 @@ void MainWindow::DrawFrameAdvantageSection() const
 	computeFramedataInteractions();
 
 	static bool isFrameAdvantageOpen = false;
-	ImGui::Checkbox("Enable", &isFrameAdvantageOpen);
+	ImGui::HorizontalSpacing();
+	ImGui::Checkbox("Enable##framedata_section", &isFrameAdvantageOpen);
 
 	if (isFrameAdvantageOpen)
 	{
@@ -166,7 +167,7 @@ void MainWindow::DrawFrameAdvantageSection() const
 
 		/* Window */
 		ImGui::Begin("Framedata", &isFrameAdvantageOpen);
-		ImGui::SetWindowSize(ImVec2(220, 100));
+		ImGui::SetWindowSize(ImVec2(220, 100), ImGuiCond_FirstUseEver);
 		ImGui::SetWindowPos(ImVec2(350, 250), ImGuiCond_FirstUseEver);
 
 		ImGui::Columns(2, "columns_layout", true);
@@ -260,7 +261,7 @@ void MainWindow::DrawHitboxOverlaySection() const
 	static bool isOpen = false;
 
 	ImGui::HorizontalSpacing();
-	if (ImGui::Checkbox("Enable", &isOpen))
+	if (ImGui::Checkbox("Enable##hitbox_overlay_section", &isOpen))
 	{
 		if (isOpen)
 		{


### PR DESCRIPTION
- Fixed "Enable" button label conflict that didn't allow the framedata window to open if the hitbox section was open

- Fixed size of the frame data window resetting to the default every frame

- Added small indentation to the "Enable" button on the framedata section on the main window